### PR TITLE
Refactor use custom datatype, add logic gate ALU

### DIFF
--- a/lib/alu/gates.ts
+++ b/lib/alu/gates.ts
@@ -1,0 +1,46 @@
+'use strict';
+
+import { Byte } from '../initial-state';
+
+const and = (a: boolean, b: boolean) => {
+  return a && b;
+};
+
+const or = (a: boolean, b: boolean) => {
+  return a || b;
+};
+
+const xor = (a: boolean, b: boolean) => {
+  if (and(a, b)) {
+    return false;
+  }
+  if (or(a, b)) {
+    return true;
+  }
+  return false;
+};
+
+const fullAdder = (a: boolean, b: boolean, c: boolean) => {
+  return {
+    c: or(and(xor(a, b), c), and(a, b)), // carry
+    s: xor(xor(a, b), c), // sum
+  };
+};
+
+const byteAdder = (a: Byte, b: Byte, c: boolean) => {
+  const { c: c1, s: s0 } = fullAdder(a[7], b[7], c);
+  const { c: c2, s: s1 } = fullAdder(a[6], b[6], c1);
+  const { c: c3, s: s2 } = fullAdder(a[5], b[5], c2);
+  const { c: c4, s: s3 } = fullAdder(a[4], b[4], c3);
+  const { c: c5, s: s4 } = fullAdder(a[3], b[3], c4);
+  const { c: c6, s: s5 } = fullAdder(a[2], b[2], c5);
+  const { c: c7, s: s6 } = fullAdder(a[1], b[1], c6);
+  const { c: carry, s: s7 } = fullAdder(a[0], b[0], c7);
+
+  const sum: Byte = [s7, s6, s5, s4, s3, s2, s1, s0];
+  const overflow = xor(c7, carry);
+
+  return { sum, carry, overflow };
+};
+
+export { and, or, xor, fullAdder, byteAdder };

--- a/lib/alu/index.ts
+++ b/lib/alu/index.ts
@@ -3,6 +3,9 @@
 import { CpuRegisters } from '../initial-state';
 import { ControlWord } from '../control';
 import { setStatusFlag } from '../register';
+import { byteAdder } from './gates';
+import { byteToNumber } from '../common';
+import { numberToByte } from '../common';
 
 const operate = ({
   registers,
@@ -17,36 +20,67 @@ const operate = ({
   return newRegisters;
 };
 
-// TODO: maybe replace with a full 8 bit adder using bitwise operators?
 const add = (registers: CpuRegisters, controlWord: ControlWord): CpuRegisters => {
   if (controlWord.dE) {
     let newRegisters: CpuRegisters = { ...registers };
 
-    let sum = newRegisters.x + newRegisters.y;
+    let { sum, carry, overflow } = byteAdder(
+      numberToByte(newRegisters.x),
+      numberToByte(newRegisters.y),
+      newRegisters.status['C'],
+    );
 
-    if (sum > 0b11111111) {
-      sum = 0b11111111;
-      newRegisters = setStatusFlag({
-        cpuRegisters: newRegisters,
-        flagsInput: controlWord.fi,
-        flag: 'C',
-        value: true,
-      });
-    } else {
-      newRegisters = setStatusFlag({
-        cpuRegisters: newRegisters,
-        flagsInput: controlWord.fi,
-        flag: 'C',
-        value: false,
-      });
-    }
-    newRegisters.s = sum;
+    newRegisters = setStatusFlag({
+      cpuRegisters: newRegisters,
+      flagsInput: controlWord.fi,
+      flag: 'C',
+      value: carry,
+    });
+
+    newRegisters = setStatusFlag({
+      cpuRegisters: newRegisters,
+      flagsInput: controlWord.fi,
+      flag: 'O',
+      value: overflow,
+    });
+    newRegisters.s = byteToNumber(sum);
 
     return newRegisters;
   }
 
   return registers;
 };
+
+// TODO: maybe replace with a full 8 bit adder using bitwise operators?
+// const add = (registers: CpuRegisters, controlWord: ControlWord): CpuRegisters => {
+//   if (controlWord.dE) {
+//     let newRegisters: CpuRegisters = { ...registers };
+
+//     let sum = newRegisters.x + newRegisters.y;
+
+//     if (sum > 0b11111111) {
+//       sum = 0b11111111;
+//       newRegisters = setStatusFlag({
+//         cpuRegisters: newRegisters,
+//         flagsInput: controlWord.fi,
+//         flag: 'C',
+//         value: true,
+//       });
+//     } else {
+//       newRegisters = setStatusFlag({
+//         cpuRegisters: newRegisters,
+//         flagsInput: controlWord.fi,
+//         flag: 'C',
+//         value: false,
+//       });
+//     }
+//     newRegisters.s = sum;
+
+//     return newRegisters;
+//   }
+
+//   return registers;
+// };
 
 const compare = (registers: CpuRegisters, controlWord: ControlWord) => {
   if (controlWord.dc) {

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { Byte } from '../initial-state';
+
 const bin2dec = (bin: string): string => {
   return parseInt(bin, 2).toString(10);
 };
@@ -8,10 +10,31 @@ const dec2bin = (dec: number): string => {
   return (dec >>> 0).toString(2);
 };
 
+const numberToByte = (num: number): Byte => {
+  return dec2bin(num)
+    .substr(-8)
+    .padStart(8, '0')
+    .split('')
+    .map((bit) => {
+      return !!+bit;
+    });
+};
+
+const byteToNumber = (byte: Byte): number => {
+  return parseInt(
+    byte
+      .map((bit) => {
+        return bit ? '1' : '0';
+      })
+      .join(''),
+    2,
+  );
+};
+
 const getLeastSignificantBits = (num: number, bits: number): number => {
   const bitString = dec2bin(num).slice(-bits);
 
   return parseInt(bitString, 2);
 };
 
-export { bin2dec, dec2bin, getLeastSignificantBits };
+export { bin2dec, dec2bin, numberToByte, byteToNumber, getLeastSignificantBits };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ const cycle = (machineState: MachineState) => {
   cpuRegisters.ic = incrementInstructionCounter(cpuRegisters.ic, controlWord);
 
   if (controlWord.oi) {
-    console.log(cpuRegisters.o);
+    console.log(cpuRegisters.o + (cpuRegisters.status.C ? 256 : 0));
   }
 
   const newMachineState: MachineState = { cpuRegisters, mainBus, systemMemory };

--- a/lib/initial-state/index.ts
+++ b/lib/initial-state/index.ts
@@ -2,6 +2,8 @@
 
 import * as fs from 'fs';
 
+type Byte = boolean[];
+
 type Bus = {
   data: number; // 16 bit
 };
@@ -86,4 +88,13 @@ const loadBinFileToMemory = (memory: Memory, fileName: string): Memory => {
   return newMemory;
 };
 
-export { Bus, CpuRegisters, Memory, setupBus, setupCpuRegisters, setupMemory, loadBinFileToMemory };
+export {
+  Byte,
+  Bus,
+  CpuRegisters,
+  Memory,
+  setupBus,
+  setupCpuRegisters,
+  setupMemory,
+  loadBinFileToMemory,
+};


### PR DESCRIPTION
This starts the transition from 64 bit Javascript numbers to arrays of boolean values to represent bytes. Right now I am using a conversion layer to move the numbers in and out of the ALU. But in the future I can add that conversion layer to any module that I want to refactor, then I can remove the conversion layers all throughout the computer once every module uses the new datatype.