### PR TITLE
perf: synchronous execution loop + tsconfig fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     "editor.formatOnSave": true
   },
   "zenMode.centerLayout": false,
-  "zenMode.hideTabs": false,
   "editor.tabSize": 2,
   "files.eol": "\n",
   "editor.formatOnSave": true,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import { setImmediateFlags, getControlWord } from './control';
 import * as alu from './alu';
 import { MachineState, clearBus, interfaceAllRegisters } from './bus';
 
-const cycle = (machineState: MachineState) => {
+const cycle = (machineState: MachineState): MachineState => {
   const controlWord = getControlWord(machineState.cpuRegisters);
 
   // eslint-disable-next-line prefer-const
@@ -37,11 +37,17 @@ const cycle = (machineState: MachineState) => {
 
   cpuRegisters.ic = incrementInstructionCounter(cpuRegisters.ic, controlWord);
 
-  const newMachineState: MachineState = { cpuRegisters, mainBus, systemMemory };
-  if (!controlWord.ht) {
-    setTimeout(() => cycle(newMachineState), 10);
-  } else {
-    process.stdout.write('', () => process.exit(0));
+  return { cpuRegisters, mainBus, systemMemory };
+};
+
+const run = (machineState: MachineState): void => {
+  let state = machineState;
+  for (;;) {
+    const controlWord = getControlWord(state.cpuRegisters);
+    state = cycle(state);
+    if (controlWord.ht) {
+      return;
+    }
   }
 };
 
@@ -59,7 +65,7 @@ const start = () => {
   let systemMemory = setupMemory();
   systemMemory = loadBinFileToMemory(systemMemory, binFile);
 
-  cycle({ cpuRegisters, mainBus, systemMemory });
+  run({ cpuRegisters, mainBus, systemMemory });
 };
 
 export { start };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "strict": true,
     "strictNullChecks": true,
     "target": "es2022",
+    "types": ["node"],
     "skipLibCheck": true
   },
   "exclude": ["node_modules", "dist", "coverage-output"]


### PR DESCRIPTION
## Changes

- **Performance**: Replace recursive `setTimeout(cycle, 10)` with a synchronous `for(;;)` loop. `cycle()` now returns `MachineState` and a new `run()` function handles the main loop. This takes test.bin from ~30 seconds down to ~47ms.
- **Fix**: Add `"types": ["node"]` to tsconfig.json to resolve `Cannot find name 'process'` TypeScript error.
- **Cleanup**: Remove deprecated `zenMode.hideTabs` from VS Code settings.

## Testing

- `npx tsc` — clean
- `npx eslint .` — clean  
- `node dist/index.js test.bin` — all 35 tests pass + Hello World output
- `node dist/index.js add1.bin` — infinite doubling loop runs at full speed