### PR TITLE
feat: memory-mapped input device + rename HLT to BRK

### DIFF
--- a/echo.s
+++ b/echo.s
@@ -1,0 +1,17 @@
+; echo.s — reads keyboard input and echoes it back
+; Ctrl+D (EOT, $04) to quit
+; Memory map:
+;   $FE01 = ASCII character output
+;   $FE02 = input status (1 = data ready)
+;   $FE03 = input data (reading clears status)
+
+poll:
+  LDA $FE02       ; check if input ready
+  BEQ poll        ; loop until data available
+  LDA $FE03       ; read the byte
+  CMP #$04        ; is it Ctrl+D (EOT)?
+  BEQ done        ; if so, quit
+  STA $FE01       ; echo character to output
+  JMP poll        ; go back for more
+done:
+  BRK             ; halt

--- a/lib/bus/index.ts
+++ b/lib/bus/index.ts
@@ -4,11 +4,13 @@ import { Bus, CpuRegisters, Memory, setupBus } from '../initial-state';
 import { ControlWord } from '../control';
 import { interfaceMemoryAddress, interfaceMemoryData } from '../memory';
 import { interfaceAllAddressRegisters, interfaceAllDataRegisters } from '../register';
+import { InputDevice } from '../memory/input-device';
 
 type MachineState = {
   cpuRegisters: CpuRegisters;
   mainBus: Bus;
   systemMemory: Memory;
+  inputDevice: InputDevice;
 };
 
 const outputToDataBus = ({ bus, data }: { bus: Bus; data: number }) => {
@@ -90,6 +92,7 @@ const interfaceAllRegisters = (
     output: true,
     input: false,
     controlWord,
+    inputDevice: machineState.inputDevice,
   }));
 
   /* Input pass next since real hardware is parallel and this is synchronous */
@@ -107,6 +110,7 @@ const interfaceAllRegisters = (
     output: false,
     input: true,
     controlWord,
+    inputDevice: machineState.inputDevice,
   }));
 
   /* Another output pass since we have 2 busses, data and address */
@@ -124,6 +128,7 @@ const interfaceAllRegisters = (
     output: true,
     input: false,
     controlWord,
+    inputDevice: machineState.inputDevice,
   }));
 
   /* Another input pass since we have 2 busses, data and address */
@@ -141,12 +146,13 @@ const interfaceAllRegisters = (
     output: false,
     input: true,
     controlWord,
+    inputDevice: machineState.inputDevice,
   }));
 
   mainBus = dataToAddressLow(mainBus, controlWord.dal);
   mainBus = dataToAddressHigh(mainBus, controlWord.dah);
 
-  return { cpuRegisters, mainBus, systemMemory };
+  return { cpuRegisters, mainBus, systemMemory, inputDevice: machineState.inputDevice };
 };
 
 export {

--- a/lib/control/index.ts
+++ b/lib/control/index.ts
@@ -6,7 +6,7 @@ import { CpuRegisters } from '../initial-state';
 type InstructionMap = { [key: string]: number };
 
 const instructionMap: InstructionMap = {
-  HLT: 0x00, // Halt the computer, stop the whole program | IMPLIED
+  BRK: 0x00, // Break — halt execution | IMPLIED
   NOP: 0xea, // No Operation, | IMPLIED
   CLC: 0x18, // Clear the carry flag | IMPLIED
   SEC: 0x38, // Set the carry flag | IMPLIED
@@ -173,7 +173,7 @@ const loadNextInstruction: MicroInstructions = [
 ];
 
 const instructions: { [key: number]: { [key: string]: MicroInstructions } } = {
-  [instructionMap.HLT]: { 0: [Object.assign({ ...baseControl }, { ht: true })] },
+  [instructionMap.BRK]: { 0: [Object.assign({ ...baseControl }, { ht: true })] },
   [instructionMap.NOP]: { 0: [] },
   [instructionMap.SEC]: {
     0: [Object.assign({ ...baseControl }, { if: [{ flag: 'C', value: true }] })],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ import { incrementProgramCounter, incrementInstructionCounter } from './register
 import { setImmediateFlags, getControlWord } from './control';
 import * as alu from './alu';
 import { MachineState, clearBus, interfaceAllRegisters } from './bus';
+import { createInputDevice, setupStdin, teardownStdin } from './memory/input-device';
 
 const cycle = (machineState: MachineState): MachineState => {
   const controlWord = getControlWord(machineState.cpuRegisters);
@@ -37,7 +38,7 @@ const cycle = (machineState: MachineState): MachineState => {
 
   cpuRegisters.ic = incrementInstructionCounter(cpuRegisters.ic, controlWord);
 
-  return { cpuRegisters, mainBus, systemMemory };
+  return { cpuRegisters, mainBus, systemMemory, inputDevice: machineState.inputDevice };
 };
 
 const run = (machineState: MachineState): void => {
@@ -46,6 +47,7 @@ const run = (machineState: MachineState): void => {
     const controlWord = getControlWord(state.cpuRegisters);
     state = cycle(state);
     if (controlWord.ht) {
+      teardownStdin(state.inputDevice);
       return;
     }
   }
@@ -64,8 +66,10 @@ const start = () => {
   const mainBus = setupBus();
   let systemMemory = setupMemory();
   systemMemory = loadBinFileToMemory(systemMemory, binFile);
+  const inputDevice = createInputDevice();
+  setupStdin(inputDevice);
 
-  run({ cpuRegisters, mainBus, systemMemory });
+  run({ cpuRegisters, mainBus, systemMemory, inputDevice });
 };
 
 export { start };

--- a/lib/memory/index.ts
+++ b/lib/memory/index.ts
@@ -3,9 +3,12 @@
 import { outputToAddressBus, outputToDataBus } from '../bus';
 import { Bus, Memory } from '../initial-state';
 import { ControlWord } from '../control';
+import { InputDevice, hasData, readByte } from './input-device';
 
 const IO_OUTPUT = 0xfe00;
 const IO_CHAR = 0xfe01;
+const IO_INPUT_STATUS = 0xfe02;
+const IO_INPUT_DATA = 0xfe03;
 
 type MemoryInterface = {
   bus: Bus;
@@ -13,10 +16,19 @@ type MemoryInterface = {
   output: boolean;
   input: boolean;
   controlWord: ControlWord;
+  inputDevice: InputDevice;
 };
 
-const interfaceMemoryData = ({ bus, memory, output, input, controlWord }: MemoryInterface) => {
+const interfaceMemoryData = ({ bus, memory, output, input, controlWord, inputDevice }: MemoryInterface) => {
   if (output && controlWord.ro) {
+    if (memory.addressRegister === IO_INPUT_STATUS) {
+      const newBus = outputToDataBus({ bus, data: hasData(inputDevice) ? 1 : 0 });
+      return { bus: newBus, memory };
+    }
+    if (memory.addressRegister === IO_INPUT_DATA) {
+      const newBus = outputToDataBus({ bus, data: readByte(inputDevice) });
+      return { bus: newBus, memory };
+    }
     const newBus = outputToDataBus({ bus, data: memory.data[memory.addressRegister] });
     return { bus: newBus, memory };
   }

--- a/lib/memory/input-device.ts
+++ b/lib/memory/input-device.ts
@@ -1,0 +1,52 @@
+'use strict';
+
+import * as fs from 'fs';
+
+type InputDevice = {
+  buffer: number[];
+  active: boolean;
+};
+
+const createInputDevice = (): InputDevice => {
+  return { buffer: [], active: false };
+};
+
+const setupStdin = (device: InputDevice): void => {
+  if (!process.stdin.isTTY) return;
+  process.stdin.setRawMode(true);
+  device.active = true;
+};
+
+const teardownStdin = (device: InputDevice): void => {
+  if (!device.active) return;
+  process.stdin.setRawMode(false);
+  device.active = false;
+};
+
+const pollStdin = (device: InputDevice): void => {
+  if (!device.active) return;
+  const buf = Buffer.alloc(64);
+  try {
+    const bytesRead = fs.readSync(0, buf, 0, 64, null);
+    for (let i = 0; i < bytesRead; i++) {
+      if (buf[i] === 3) {
+        teardownStdin(device);
+        process.exit();
+      }
+      device.buffer.push(buf[i]);
+    }
+  } catch {
+    // EAGAIN — no data available, which is expected
+  }
+};
+
+const hasData = (device: InputDevice): boolean => {
+  pollStdin(device);
+  return device.buffer.length > 0;
+};
+
+const readByte = (device: InputDevice): number => {
+  return device.buffer.shift() ?? 0;
+};
+
+export { InputDevice, createInputDevice, hasData, readByte, setupStdin, teardownStdin };


### PR DESCRIPTION
## Changes

### Memory-mapped input device
- New `InputDevice` that polls stdin via non-blocking `fs.readSync` — works with our synchronous main loop
- **$FE02** — input status register (returns 1 if byte waiting, 0 if not)
- **$FE03** — input data register (reads byte and clears from buffer)
- Raw mode enabled when running on a TTY; Ctrl+C exits immediately
- Piped input works transparently (no raw mode)

### 6502 compatibility
- Renamed `HLT` to `BRK` — opcode 0x00 unchanged, now matches real 6502 naming

### Demo program
- `echo.s` — polls for keyboard input, echoes characters to ASCII output, Ctrl+D to quit

## Memory map
| Address | Direction | Description |
|---------|-----------|-------------|
| $FE00 | Write | Numeric stdout (prints decimal value) |
| $FE01 | Write | ASCII character stdout |
| $FE02 | Read | Input status (1 = data ready) |
| $FE03 | Read | Input data (consumes byte from buffer) |

## Testing
- `npx tsc` — clean
- `npx eslint .` — clean
- `node dist/index.js test.bin` — all 35 tests + Hello World pass
- `node dist/index.js echo.bin` — interactive echo tested manually