### PR TITLE
feat: stack operations + debug mode

### DIFF
--- a/echo.s
+++ b/echo.s
@@ -5,6 +5,8 @@
 ;   $FE02 = input status (1 = data ready)
 ;   $FE03 = input data (reading clears status)
 
+* = $0200
+
 poll:
   LDA $FE02       ; check if input ready
   BEQ poll        ; loop until data available

--- a/lib/control/index.ts
+++ b/lib/control/index.ts
@@ -70,6 +70,14 @@ const instructionMap: InstructionMap = {
   BPL: 0x10, // Branch if negative flag clear | RELATIVE
   BVS: 0x70, // Branch if overflow set | RELATIVE
   BVC: 0x50, // Branch if overflow clear | RELATIVE
+  JSR: 0x20, // Jump to subroutine | ABSOLUTE
+  RTS: 0x60, // Return from subroutine | IMPLIED
+  PHA: 0x48, // Push accumulator | IMPLIED
+  PLA: 0x68, // Pull accumulator | IMPLIED
+  PHP: 0x08, // Push processor status | IMPLIED
+  PLP: 0x28, // Pull processor status | IMPLIED
+  TXS: 0x9a, // Transfer X to stack pointer | IMPLIED
+  TSX: 0xba, // Transfer stack pointer to X | IMPLIED
 };
 
 type ControlWord = {
@@ -116,6 +124,14 @@ type ControlWord = {
   zn: boolean; // set Z and N flags from data bus value
   fi: boolean; // cpu status flags in
   ht: boolean; // halt the computer
+  spd: boolean; // decrement stack pointer (post-write)
+  spu: boolean; // increment stack pointer (pre-read)
+  pcho: boolean; // output PC high byte to data bus
+  pclo: boolean; // output PC low byte to data bus
+  spdo: boolean; // output stack pointer to data bus
+  spdi: boolean; // input stack pointer from data bus
+  sto: boolean; // output status register as byte to data bus
+  sti: boolean; // input status register from data bus byte
   if: { flag: string; value: boolean }[]; // Cpu status flags to set immediately
 };
 
@@ -163,6 +179,14 @@ const baseControl: ControlWord = {
   zn: false, // set Z and N flags from data bus value
   fi: false, // cpu status flags in
   ht: false, // halt the computer
+  spd: false, // decrement stack pointer (post-write)
+  spu: false, // increment stack pointer (pre-read)
+  pcho: false, // output PC high byte to data bus
+  pclo: false, // output PC low byte to data bus
+  spdo: false, // output stack pointer to data bus
+  spdi: false, // input stack pointer from data bus
+  sto: false, // output status register as byte to data bus
+  sti: false, // input status register from data bus byte
   if: [], // Cpu status flags to set immediately
 };
 
@@ -558,6 +582,53 @@ const instructions: { [key: number]: { [key: string]: MicroInstructions } } = {
   [instructionMap.BVC]: {
     O: [Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, pce: true })],
     0: [Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true, bra: true })],
+  },
+  // Stack operations
+  [instructionMap.JSR]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, pcho: true, ri: true, spd: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, pclo: true, ri: true, spd: true }),
+      Object.assign({ ...baseControl }, { bao: true, pcai: true, bac: true }),
+    ],
+  },
+  [instructionMap.RTS]: {
+    0: [
+      Object.assign({ ...baseControl }, { spu: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, ro: true, dal: true }),
+      Object.assign({ ...baseControl }, { spu: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, ro: true, dah: true }),
+      Object.assign({ ...baseControl }, { bao: true, pcai: true, bac: true }),
+    ],
+  },
+  [instructionMap.PHA]: {
+    0: [
+      Object.assign({ ...baseControl }, { spo: true, mi: true, ao: true, ri: true, spd: true }),
+    ],
+  },
+  [instructionMap.PLA]: {
+    0: [
+      Object.assign({ ...baseControl }, { spu: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, ro: true, ai: true, zn: true }),
+    ],
+  },
+  [instructionMap.PHP]: {
+    0: [
+      Object.assign({ ...baseControl }, { spo: true, mi: true, sto: true, ri: true, spd: true }),
+    ],
+  },
+  [instructionMap.PLP]: {
+    0: [
+      Object.assign({ ...baseControl }, { spu: true }),
+      Object.assign({ ...baseControl }, { spo: true, mi: true, ro: true, sti: true }),
+    ],
+  },
+  [instructionMap.TXS]: {
+    0: [Object.assign({ ...baseControl }, { xo: true, spdi: true })],
+  },
+  [instructionMap.TSX]: {
+    0: [Object.assign({ ...baseControl }, { spdo: true, xi: true, zn: true })],
   },
 };
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,17 +1,50 @@
 'use strict';
 
-import { setupBus, setupCpuRegisters, setupMemory, loadBinFileToMemory } from './initial-state';
+import { setupBus, setupCpuRegisters, setupMemory, loadBinFileToMemory, LOAD_ADDRESS } from './initial-state';
+import { instructionMap } from './control';
 import { incrementProgramCounter, incrementInstructionCounter } from './register';
 import { setImmediateFlags, getControlWord } from './control';
 import * as alu from './alu';
 import { MachineState, clearBus, interfaceAllRegisters } from './bus';
 import { createInputDevice, setupStdin, teardownStdin } from './memory/input-device';
 
+const opcodeNames: Map<number, string> = new Map(
+  Object.entries(instructionMap).map(([name, opcode]) => [opcode, name]),
+);
+
+const formatStatus = (status: { [key: string]: boolean }): string => {
+  return ['N', 'O', 'B', 'D', 'I', 'Z', 'C']
+    .map((f) => (status[f] ? f : f.toLowerCase()))
+    .join('');
+};
+
+let debugMode = false;
+
 const cycle = (machineState: MachineState): MachineState => {
   const controlWord = getControlWord(machineState.cpuRegisters);
 
+  if (debugMode && machineState.cpuRegisters.ic === 0) {
+    const r = machineState.cpuRegisters;
+    const opcode = machineState.systemMemory.data[r.pc] ?? 0;
+    const name = opcodeNames.get(opcode) ?? `???($${opcode.toString(16).padStart(2, '0')})`;
+    process.stderr.write(
+      `PC=$${r.pc.toString(16).padStart(4, '0')} ${name.padEnd(5)} ` +
+      `A=$${r.a.toString(16).padStart(2, '0')} X=$${r.x.toString(16).padStart(2, '0')} ` +
+      `Y=$${r.y.toString(16).padStart(2, '0')} SP=$${r.sp.toString(16).padStart(2, '0')} ` +
+      `[${formatStatus(r.status)}]\n`,
+    );
+  }
+
+  let currentState = machineState;
+  if (controlWord.spu) {
+    currentState = {
+      ...currentState,
+      cpuRegisters: { ...currentState.cpuRegisters, sp: (currentState.cpuRegisters.sp + 1) & 0xff },
+    };
+  }
+
   // eslint-disable-next-line prefer-const
-  let { cpuRegisters, mainBus, systemMemory } = interfaceAllRegisters(machineState, controlWord);
+  let { cpuRegisters, mainBus, systemMemory } = interfaceAllRegisters(currentState, controlWord);
 
   if (controlWord.zn) {
     cpuRegisters.status.Z = mainBus.data === 0;
@@ -30,6 +63,10 @@ const cycle = (machineState: MachineState): MachineState => {
   cpuRegisters = alu.operate({ registers: cpuRegisters, controlWord });
 
   cpuRegisters.pc = incrementProgramCounter(cpuRegisters.pc, controlWord.pce);
+
+  if (controlWord.spd) {
+    cpuRegisters.sp = (cpuRegisters.sp - 1) & 0xff;
+  }
 
   if (controlWord.bra) {
     const offset = cpuRegisters.aluA > 127 ? cpuRegisters.aluA - 256 : cpuRegisters.aluA;
@@ -56,13 +93,15 @@ const run = (machineState: MachineState): void => {
 /* ##################################################################### */
 
 const start = () => {
-  const binFile = process.argv[2];
+  debugMode = process.argv.includes('--debug');
+  const binFile = process.argv.find((arg) => arg !== '--debug' && !arg.includes('node') && !arg.includes('index.js'));
   if (!binFile) {
-    console.error('Usage: simplecpu <file.bin>');
+    console.error('Usage: simplecpu <file.bin> [--debug]');
     process.exit(1);
   }
 
   const cpuRegisters = setupCpuRegisters();
+  cpuRegisters.pc = LOAD_ADDRESS;
   const mainBus = setupBus();
   let systemMemory = setupMemory();
   systemMemory = loadBinFileToMemory(systemMemory, binFile);

--- a/lib/initial-state/index.ts
+++ b/lib/initial-state/index.ts
@@ -57,7 +57,7 @@ const setupCpuRegisters = (): CpuRegisters => {
     i: 0b0000000000000000,
     ic: 0b00000000,
     pc: 0b0000000000000000,
-    sp: 0b00000000,
+    sp: 0xff,
     o: 0b00000000,
     status: {
       C: false,
@@ -84,16 +84,15 @@ const setupMemory = (): Memory => {
   return mem;
 };
 
+const LOAD_ADDRESS = 0x0200;
+
 const loadBinFileToMemory = (memory: Memory, fileName: string): Memory => {
   const newMemory = { ...memory };
   const file = fs.readFileSync(fileName, { encoding: 'hex' });
   const chunks = file.match(/.{2}/g) || [];
-  const memoryContents: number[] = [];
   chunks.forEach((chunk, index) => {
-    memoryContents[index] = parseInt(chunk, 16);
+    newMemory.data[LOAD_ADDRESS + index] = parseInt(chunk, 16);
   });
-
-  newMemory.data = memoryContents;
 
   return newMemory;
 };
@@ -103,6 +102,7 @@ export {
   Bus,
   CpuRegisters,
   Memory,
+  LOAD_ADDRESS,
   setupBus,
   setupCpuRegisters,
   setupMemory,

--- a/lib/register/index.ts
+++ b/lib/register/index.ts
@@ -130,12 +130,9 @@ const interfaceAllAddressRegisters = ({
     input: input && controlWord.pcai,
   }));
 
-  ({ bus: mainBus, register: cpuRegisters.sp } = interfaceRegisterAddress({
-    bus: mainBus,
-    register: cpuRegisters.sp,
-    output: output && controlWord.spo,
-    input: input && controlWord.spi,
-  }));
+  if (output && controlWord.spo) {
+    mainBus = outputToAddressBus({ bus: mainBus, address: 0x0100 | cpuRegisters.sp });
+  }
 
   return { bus: mainBus, registers: cpuRegisters };
 };
@@ -205,7 +202,52 @@ const interfaceAllDataRegisters = ({
     input: input && controlWord.lb,
   }));
 
+  if (output && controlWord.pcho) {
+    mainBus = outputToDataBus({ bus: mainBus, data: (cpuRegisters.pc >> 8) & 0xff });
+  }
+  if (output && controlWord.pclo) {
+    mainBus = outputToDataBus({ bus: mainBus, data: cpuRegisters.pc & 0xff });
+  }
+  if (output && controlWord.spdo) {
+    mainBus = outputToDataBus({ bus: mainBus, data: cpuRegisters.sp });
+  }
+  if (output && controlWord.sto) {
+    mainBus = outputToDataBus({ bus: mainBus, data: statusToByte(cpuRegisters.status) });
+  }
+
+  if (input && controlWord.spdi) {
+    cpuRegisters.sp = mainBus.data;
+  }
+  if (input && controlWord.sti) {
+    cpuRegisters.status = byteToStatus(mainBus.data);
+  }
+
   return { bus: mainBus, registers: cpuRegisters };
+};
+
+const statusToByte = (status: CpuRegisters['status']): number => {
+  return (
+    (status.N ? 0x80 : 0) |
+    (status.O ? 0x40 : 0) |
+    0x20 |
+    (status.B ? 0x10 : 0) |
+    (status.D ? 0x08 : 0) |
+    (status.I ? 0x04 : 0) |
+    (status.Z ? 0x02 : 0) |
+    (status.C ? 0x01 : 0)
+  );
+};
+
+const byteToStatus = (byte: number): CpuRegisters['status'] => {
+  return {
+    N: (byte & 0x80) !== 0,
+    O: (byte & 0x40) !== 0,
+    B: (byte & 0x10) !== 0,
+    D: (byte & 0x08) !== 0,
+    I: (byte & 0x04) !== 0,
+    Z: (byte & 0x02) !== 0,
+    C: (byte & 0x01) !== 0,
+  };
 };
 
 const incrementProgramCounter = (register: number, counterEnable: boolean): number => {

--- a/test.s
+++ b/test.s
@@ -1,9 +1,9 @@
 ; simpleCPU test suite
 ; Exercises every implemented instruction
 ; Output to $FE00 — each STA $FE00 prints a test result
-; Expected output: 1 through 34, then 3 2 1 35, then Hello World!
+; Expected output: 1 through 34, then 3 2 1 35, 36 37 38 39 40, then Hello World!
 
-* = $0000
+* = $0200
 
 ; --- Test 1: LDA immediate ---
         LDA #$01        ; A=1
@@ -15,9 +15,9 @@
         STA $FE00       ; output 2
 
 ; --- Test 3: STA / LDA absolute ---
-        STA $0300       ; store 2 at $0300
+        STA $0500       ; store 2 at $0500
         LDA #$00        ; clear A
-        LDA $0300       ; reload from $0300, A=2
+        LDA $0500       ; reload from $0500, A=2
         CLC
         ADC #$01        ; A=3
         STA $FE00       ; output 3
@@ -52,22 +52,22 @@
 
 ; --- Test 10: LDX absolute ---
         LDA #$0A
-        STA $0300
-        LDX $0300       ; X=10
+        STA $0500
+        LDX $0500       ; X=10
         STX $FE00       ; output 10
 
 ; --- Test 11: LDY absolute ---
         LDA #$0B
-        STA $0300
-        LDY $0300       ; Y=11
+        STA $0500
+        LDY $0500       ; Y=11
         STY $FE00       ; output 11
 
 ; --- Test 12: ADC absolute ---
         LDA #$06
-        STA $0300       ; store 6
+        STA $0500       ; store 6
         LDA #$06
         CLC
-        ADC $0300       ; A=6+6=12
+        ADC $0500       ; A=6+6=12
         STA $FE00       ; output 12
 
 ; --- Test 13: SBC immediate ---
@@ -78,10 +78,10 @@
 
 ; --- Test 14: SBC absolute ---
         LDA #$04
-        STA $0300       ; store 4
+        STA $0500       ; store 4
         LDA #$12        ; A=18
         SEC
-        SBC $0300       ; A=18-4=14
+        SBC $0500       ; A=18-4=14
         STA $FE00       ; output 14
 
 ; --- Test 15: AND immediate ---
@@ -91,9 +91,9 @@
 
 ; --- Test 16: AND absolute ---
         LDA #$F0
-        STA $0300
+        STA $0500
         LDA #$1F
-        AND $0300       ; A=$1F & $F0 = $10 = 16
+        AND $0500       ; A=$1F & $F0 = $10 = 16
         STA $FE00       ; output 16
 
 ; --- Test 17: ORA immediate ---
@@ -103,9 +103,9 @@
 
 ; --- Test 18: ORA absolute ---
         LDA #$02
-        STA $0300
+        STA $0500
         LDA #$10
-        ORA $0300       ; A=$10 | $02 = $12 = 18
+        ORA $0500       ; A=$10 | $02 = $12 = 18
         STA $FE00       ; output 18
 
 ; --- Test 19: EOR immediate ---
@@ -125,9 +125,9 @@
 ; need A XOR mem = 20 = $14 = 00010100
 ; $FF ^ $EB = $14? $EB=11101011 XOR $FF=11111111 = 00010100 = $14 = 20 yes
         LDA #$EB
-        STA $0300
+        STA $0500
         LDA #$FF
-        EOR $0300       ; A=$FF ^ $EB = $14 = 20
+        EOR $0500       ; A=$FF ^ $EB = $14 = 20
         STA $FE00       ; output 20
 
 ; --- Test 21: ASL accumulator ---
@@ -168,10 +168,10 @@
         STX $FE00       ; output 25
 ; verify Y survived
         LDA #$AA
-        STA $0300
-        STY $0301
-        LDA $0301
-        CMP $0300       ; Y should still be $AA
+        STA $0500
+        STY $0501
+        LDA $0501
+        CMP $0500       ; Y should still be $AA
 ; (if Z is not set, something went wrong — but we can't branch yet)
 
 ; --- Test 26: INY / DEY ---
@@ -181,10 +181,10 @@
         STY $FE00       ; output 26
 ; verify X survived
         LDA #$BB
-        STA $0300
-        STX $0301
-        LDA $0301
-        CMP $0300       ; X should still be $BB
+        STA $0500
+        STX $0501
+        LDA $0501
+        CMP $0500       ; X should still be $BB
 
 ; --- Test 27: BEQ (branch if Z=1) ---
         LDA #$00        ; Z=1
@@ -254,19 +254,51 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         LDA #$23        ; 35
         STA $FE00       ; output 35
 
+; --- Test 36: PHA / PLA ---
+        LDA #$24        ; 36
+        PHA             ; push 36
+        LDA #$00        ; clear A
+        PLA             ; pull 36 back
+        STA $FE00       ; output 36
+
+; --- Test 37: TXS / TSX ---
+        LDX #$FF
+        TXS             ; SP=$FF
+        LDX #$00        ; clear X
+        TSX             ; X should be $FF
+        LDX #$FF
+        TXS             ; restore SP=$FF
+        LDA #$25        ; 37
+        STA $FE00       ; output 37
+
+; --- Test 38: JSR / RTS ---
+        JSR SUB38       ; subroutine outputs 38
+
+; --- Test 39: PHP / PLP ---
+        SEC             ; C=1
+        PHP             ; push status
+        CLC             ; C=0
+        PLP             ; restore status (C=1)
+        LDA #$26        ; 38
+        ADC #$00        ; 38+0+1(carry)=39
+        STA $FE00       ; output 39
+
+; --- Test 40: Nested JSR ---
+        JSR SUB40       ; calls SUB40B which outputs 40
+
 ; --- Smoke tests for remaining instructions (no output, just must not crash) ---
 
 ; STX / STY absolute
         LDX #$42
-        STX $0300
+        STX $0500
         LDY #$43
-        STY $0301
+        STY $0501
 
 ; INC / DEC memory
         LDA #$09
-        STA $0300
-        INC $0300       ; mem[$0300]=10
-        DEC $0300       ; mem[$0300]=9
+        STA $0500
+        INC $0500       ; mem[$0500]=10
+        DEC $0500       ; mem[$0500]=9
 
 ; CMP immediate / absolute
         LDA #$05
@@ -274,9 +306,9 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CMP #$06        ; Z=0, C=0
 
         LDA #$05
-        STA $0300
+        STA $0500
         LDA #$05
-        CMP $0300       ; Z=1, C=1
+        CMP $0500       ; Z=1, C=1
 
 ; CPX immediate / absolute
         LDX #$10
@@ -284,8 +316,8 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CPX #$11        ; Z=0, C=0
 
         LDA #$10
-        STA $0300
-        CPX $0300       ; Z=1, C=1
+        STA $0500
+        CPX $0500       ; Z=1, C=1
 
 ; CPY immediate / absolute
         LDY #$20
@@ -293,24 +325,24 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CPY #$21        ; Z=0, C=0
 
         LDA #$20
-        STA $0300
-        CPY $0300       ; Z=1, C=1
+        STA $0500
+        CPY $0500       ; Z=1, C=1
 
 ; ASL / LSR / ROL / ROR absolute
         LDA #$02
-        STA $0300
-        ASL $0300       ; mem[$0300]=4
-        LSR $0300       ; mem[$0300]=2
+        STA $0500
+        ASL $0500       ; mem[$0500]=4
+        LSR $0500       ; mem[$0500]=2
         CLC
-        ROL $0300       ; mem[$0300]=4
+        ROL $0500       ; mem[$0500]=4
         CLC
-        ROR $0300       ; mem[$0300]=2
+        ROR $0500       ; mem[$0500]=2
 
 ; BIT absolute
         LDA #$FF
-        STA $0300
+        STA $0500
         LDA #$0F
-        BIT $0300       ; Z=0 (0F & FF != 0), N=1, V=1
+        BIT $0500       ; Z=0 (0F & FF != 0), N=1, V=1
 
 ; SEC / CLC
         SEC
@@ -333,6 +365,18 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
 ; JMP
         JMP HELLO
         BRK             ; should be skipped
+
+; --- Subroutine definitions ---
+SUB38   LDA #$26        ; 38
+        STA $FE00       ; output 38
+        RTS
+
+SUB40   JSR SUB40B
+        RTS
+
+SUB40B  LDA #$28        ; 40
+        STA $FE00       ; output 40
+        RTS
 
 ; --- Hello World via character I/O at $FE01 ---
 HELLO   LDA #$48        ; 'H'


### PR DESCRIPTION
## Stack Operations
Implements the 6502 stack with 8 new instructions:
- **JSR/RTS** — subroutine call and return (PC pushed/pulled from stack)
- **PHA/PLA** — push/pull accumulator
- **PHP/PLP** — push/pull processor status (6502-compatible NV-BDIZC byte format)
- **TXS/TSX** — transfer X to/from stack pointer

SP initialized to $FF. Stack page hardwired at $0100-$01FF. Push post-decrements SP, pull pre-increments — matching real 6502 semantics.

## Debug Mode
`--debug` flag logs PC, opcode mnemonic, A/X/Y/SP, and status flags to stderr at each instruction boundary. Output goes to stderr so it doesn't interfere with program output.

## Load Address Fix
Programs now load at $0200 (above the stack page) with PC starting at $0200. Previously programs loaded at $0000, causing stack pushes to overwrite program code. Assembly files updated with `* = $0200`.

## Tests
5 new tests (36-40) covering PHA/PLA, TXS/TSX, JSR/RTS, PHP/PLP, and nested subroutine calls. All 40 tests pass.