### PR TITLE
feat: addressing modes — zero page, indexed, indirect

### DIFF
--- a/addressing-modes-plan.md
+++ b/addressing-modes-plan.md
@@ -1,0 +1,149 @@
+# Addressing Modes Implementation Plan
+
+## Overview
+Add zero page, indexed, and indirect addressing modes to simpleCPU. Each step builds on the previous and is independently testable. All address math routes through the existing ALU (matching real 6502 architecture).
+
+## Step 1: Zero Page ✅ if done
+**Example:** `LDA $42` (opcode $A5)
+
+No new signals needed. Same as absolute but fetch only 1 address byte — high byte is implicitly $00.
+
+**Instructions to add:**
+- LDA $zp ($A5), STA $zp ($85)
+- LDX $zp ($A6), STX $zp ($86)
+- LDY $zp ($A4), STY $zp ($84)
+- ADC $zp ($65), SBC $zp ($E5)
+- AND $zp ($25), ORA $zp ($05), EOR $zp ($45)
+- CMP $zp ($C5), CPX $zp ($E4), CPY $zp ($C4)
+- BIT $zp ($24)
+- ASL $zp ($06), LSR $zp ($46), ROL $zp ($26), ROR $zp ($66)
+- INC $zp ($E6), DEC $zp ($C6)
+
+**Microcode pattern (read):**
+```
+fetch operand → dal (address low byte, high stays $00)
+bao, mi, ro, <dest>, bac
+```
+
+**Test:** Store value at zero page, read it back, verify.
+
+---
+
+## Step 2: Zero Page,X / Zero Page,Y
+**Example:** `LDA $42,X` (opcode $B5)
+
+First use of ALU for address math. Needs one new signal: add with carry forced to 0, no flag side effects.
+
+**New signal:** `dEa` (or similar) — add aluA + aluB with carry=0, result in S register, flags unchanged.
+
+**Microcode pattern:**
+```
+fetch operand → la (base address into aluA)
+xo → lb (X into aluB)
+dEa (add, no carry, no flags)
+so → dal (result into address low, high stays $00)
+bao, mi, ro, <dest>, bac
+```
+
+Zero page wraps: $FF + $01 = $00, stays in page zero (natural 8-bit overflow).
+
+**Instructions:** Same as step 1 but with ,X or ,Y suffix. ZP,Y only exists for LDX and STX.
+
+**Test:** `LDX #$05; STA $40; LDA $3B,X` → loads from $0040.
+
+---
+
+## Step 3: Absolute,X / Absolute,Y
+**Example:** `LDA $1000,X` (opcode $BD)
+
+Same ALU addition but on 16-bit base address. Add index to low byte; if ALU produces carry, increment high byte in a subsequent cycle.
+
+**Microcode pattern:**
+```
+fetch addr_low → la, pce
+fetch addr_high → dah, pce
+xo → lb
+dEa (add low byte + X, check carry)
+so → dal
+bao, mi, ro, <dest>, bac
+(if carry: fix up high byte — extra cycle)
+```
+
+**Page crossing:** $10FF + X=2 → need to detect carry and add 1 to high byte $10 → $11.
+
+**Instructions:** Most read/write ops with ,X; LDA, STA, ADC, SBC, AND, ORA, EOR, CMP, LDX,Y, LDY,X, etc.
+
+**Test:** Verify with and without page crossing.
+
+---
+
+## Step 4: JMP Indirect
+**Example:** `JMP ($1000)` (opcode $6C)
+
+Read a 16-bit pointer from memory at the operand address, set PC to that pointer value. No ALU math needed.
+
+**Microcode pattern:**
+```
+fetch ptr_addr_low → dal, pce
+fetch ptr_addr_high → dah, pce
+bao, mi, ro, dal2 (read low byte of target)   — need temp storage
+inc address, mi, ro, dah2 (read high byte of target)
+bao, pcai, bac (set PC)
+```
+
+Note: Real 6502 has a famous bug — indirect JMP doesn't cross page boundaries ($xxFF wraps to $xx00). We should replicate this for compatibility.
+
+**Test:** Store a 16-bit address in memory, JMP indirect to it.
+
+---
+
+## Step 5: Indexed Indirect — (Indirect,X)
+**Example:** `LDA ($40,X)` (opcode $A1)
+
+Combine step 2 (zero page + X) with step 4 (pointer dereference). Add X to zero page address, read 16-bit pointer from that location, load from pointed address.
+
+**Microcode pattern:**
+```
+fetch zp_base → la
+xo → lb
+dEa (zp_base + X, wraps in zero page)
+so → dal (effective ZP address)
+bao, mi, ro, dal2 (read ptr low)
+bao+1, mi, ro, dah2 (read ptr high)
+bao2, mi, ro, <dest>, bac
+```
+
+**Instructions:** LDA, STA, ADC, SBC, AND, ORA, EOR, CMP.
+
+**Test:** Set up a pointer in zero page, index with X, verify load.
+
+---
+
+## Step 6: Indirect Indexed — (Indirect),Y
+**Example:** `LDA ($40),Y` (opcode $B1)
+
+Read 16-bit pointer from zero page, then add Y to the result. The most important indirect mode — pointer + offset access.
+
+**Microcode pattern:**
+```
+fetch zp_addr → dal (zero page address of pointer)
+bao, mi, ro, dal2 (read ptr low byte)
+bao+1, mi, ro, dah2 (read ptr high byte)  
+ptr_low → la, yo → lb
+dEa (ptr_low + Y)
+so → dal (new low byte, carry may need high byte fix)
+bao, mi, ro, <dest>, bac
+```
+
+**Instructions:** Same as step 5.
+
+**Test:** Set up a pointer, add Y offset, verify load from computed address.
+
+---
+
+## Architecture Notes
+- All address math goes through the existing ALU (aluA/aluB → byteAdder → S register)
+- Need "add with zero carry, no flag update" to avoid corrupting program state during address calculation
+- Zero page indexed wraps within page zero (8-bit overflow)
+- Absolute indexed may cross page boundaries (needs carry propagation to high byte)
+- The real 6502 uses its single ALU for both data and address math — we match this

--- a/lib/alu/index.ts
+++ b/lib/alu/index.ts
@@ -17,6 +17,7 @@ const operate = ({
   controlWord: ControlWord;
 }): CpuRegisters => {
   let newRegisters = add(registers, controlWord);
+  newRegisters = addressAdd(newRegisters, controlWord);
   newRegisters = subtract(newRegisters, controlWord);
   newRegisters = bitwiseAnd(newRegisters, controlWord);
   newRegisters = bitwiseOr(newRegisters, controlWord);
@@ -50,6 +51,21 @@ const add = (registers: CpuRegisters, controlWord: ControlWord): CpuRegisters =>
     return newRegisters;
   }
 
+  return registers;
+};
+
+const addressAdd = (registers: CpuRegisters, controlWord: ControlWord): CpuRegisters => {
+  if (controlWord.dEa) {
+    const newRegisters: CpuRegisters = { ...registers };
+    const { sum, carry } = byteAdder(
+      numberToByte(newRegisters.aluA),
+      numberToByte(newRegisters.aluB),
+      false,
+    );
+    newRegisters.s = byteToNumber(sum);
+    newRegisters.addressCarry = carry;
+    return newRegisters;
+  }
   return registers;
 };
 

--- a/lib/bus/index.ts
+++ b/lib/bus/index.ts
@@ -60,12 +60,9 @@ const busRegisterToAddress = (bus: Bus, enable: boolean): Bus => {
   return bus;
 };
 
-const clearBus = (bus: Bus, controlWord: ControlWord) => {
+const clearBus = (bus: Bus) => {
   const newBus = setupBus();
-  if (!controlWord.bac) {
-    newBus.addressRegister = bus.addressRegister;
-  }
-
+  newBus.addressRegister = bus.addressRegister;
   return newBus;
 };
 
@@ -149,11 +146,19 @@ const interfaceAllRegisters = (
     inputDevice: machineState.inputDevice,
   }));
 
+  if (controlWord.bac) {
+    mainBus = { ...mainBus, addressRegister: 0 };
+  }
+
   mainBus = dataToAddressLow(mainBus, controlWord.dal);
   mainBus = dataToAddressHigh(mainBus, controlWord.dah);
 
   if (controlWord.dahc && cpuRegisters.addressCarry) {
     mainBus = { ...mainBus, addressRegister: (mainBus.addressRegister + 0x100) & 0xffff };
+  }
+
+  if (controlWord.bai) {
+    mainBus = { ...mainBus, addressRegister: (mainBus.addressRegister + 1) & 0xffff };
   }
 
   return { cpuRegisters, mainBus, systemMemory, inputDevice: machineState.inputDevice };

--- a/lib/bus/index.ts
+++ b/lib/bus/index.ts
@@ -152,6 +152,10 @@ const interfaceAllRegisters = (
   mainBus = dataToAddressLow(mainBus, controlWord.dal);
   mainBus = dataToAddressHigh(mainBus, controlWord.dah);
 
+  if (controlWord.dahc && cpuRegisters.addressCarry) {
+    mainBus = { ...mainBus, addressRegister: (mainBus.addressRegister + 0x100) & 0xffff };
+  }
+
   return { cpuRegisters, mainBus, systemMemory, inputDevice: machineState.inputDevice };
 };
 

--- a/lib/control/index.ts
+++ b/lib/control/index.ts
@@ -136,6 +136,25 @@ const instructionMap: InstructionMap = {
   ORAAY: 0x19, // ORA absolute,Y | ABSOLUTE,Y
   EORAY: 0x59, // EOR absolute,Y | ABSOLUTE,Y
   CMPAY: 0xd9, // CMP absolute,Y | ABSOLUTE,Y
+  JMPI: 0x6c, // Jump indirect | INDIRECT
+  // Indexed indirect (indirect,X)
+  LDAIX: 0xa1, // LDA (zp,X) | INDEXED INDIRECT
+  STAIX: 0x81, // STA (zp,X) | INDEXED INDIRECT
+  ADCIX: 0x61, // ADC (zp,X) | INDEXED INDIRECT
+  SBCIX: 0xe1, // SBC (zp,X) | INDEXED INDIRECT
+  ANDIX: 0x21, // AND (zp,X) | INDEXED INDIRECT
+  ORAIX: 0x01, // ORA (zp,X) | INDEXED INDIRECT
+  EORIX: 0x41, // EOR (zp,X) | INDEXED INDIRECT
+  CMPIX: 0xc1, // CMP (zp,X) | INDEXED INDIRECT
+  // Indirect indexed (indirect),Y
+  LDAIY: 0xb1, // LDA (zp),Y | INDIRECT INDEXED
+  STAIY: 0x91, // STA (zp),Y | INDIRECT INDEXED
+  ADCIY: 0x71, // ADC (zp),Y | INDIRECT INDEXED
+  SBCIY: 0xf1, // SBC (zp),Y | INDIRECT INDEXED
+  ANDIY: 0x31, // AND (zp),Y | INDIRECT INDEXED
+  ORAIY: 0x11, // ORA (zp),Y | INDIRECT INDEXED
+  EORIY: 0x51, // EOR (zp),Y | INDIRECT INDEXED
+  CMPIY: 0xd1, // CMP (zp),Y | INDIRECT INDEXED
   JSR: 0x20, // Jump to subroutine | ABSOLUTE
   RTS: 0x60, // Return from subroutine | IMPLIED
   PHA: 0x48, // Push accumulator | IMPLIED
@@ -184,6 +203,7 @@ type ControlWord = {
   ror: boolean; // rotate right x register through carry
   bit: boolean; // bit test aluA AND aluB, set flags only
   la: boolean; // latch ALU input A from data bus
+  lao: boolean; // output ALU input A to data bus
   lb: boolean; // latch ALU input B from data bus
   c1: boolean; // load constant 1 into ALU input B
   bra: boolean; // branch relative: add signed data bus value to PC
@@ -200,6 +220,7 @@ type ControlWord = {
   sti: boolean; // input status register from data bus byte
   dEa: boolean; // address add: aluA + aluB with carry=0, no flag updates
   dahc: boolean; // add address carry to high byte of bus address register
+  bai: boolean; // increment bus address register by 1
   if: { flag: string; value: boolean }[]; // Cpu status flags to set immediately
 };
 
@@ -241,6 +262,7 @@ const baseControl: ControlWord = {
   ror: false, // rotate right x register through carry
   bit: false, // bit test aluA AND aluB, set flags only
   la: false, // latch ALU input A from data bus
+  lao: false, // output ALU input A to data bus
   lb: false, // latch ALU input B from data bus
   c1: false, // load constant 1 into ALU input B
   bra: false, // branch relative: add signed data bus value to PC
@@ -257,6 +279,7 @@ const baseControl: ControlWord = {
   sti: false, // input status register from data bus byte
   dEa: false, // address add: aluA + aluB with carry=0, no flag updates
   dahc: false, // add address carry to high byte of bus address register
+  bai: false, // increment bus address register by 1
   if: [], // Cpu status flags to set immediately
 };
 
@@ -1262,6 +1285,225 @@ const instructions: { [key: number]: { [key: string]: MicroInstructions } } = {
     0: [
       Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
       Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  // JMP indirect — read 16-bit pointer from memory, jump to target
+  [instructionMap.JMPI]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, pcai: true, bac: true }),
+    ],
+  },
+  // Indexed indirect (indirect,X) — ZP+X pointer dereference
+  [instructionMap.LDAIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ADCIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPIX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { lao: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  // Indirect indexed (indirect),Y — ZP pointer + Y offset
+  [instructionMap.LDAIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ADCIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPIY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true, bai: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, dah: true, bac: true }),
       Object.assign({ ...baseControl }, { yo: true, lb: true }),
       Object.assign({ ...baseControl }, { dEa: true }),
       Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),

--- a/lib/control/index.ts
+++ b/lib/control/index.ts
@@ -70,6 +70,72 @@ const instructionMap: InstructionMap = {
   BPL: 0x10, // Branch if negative flag clear | RELATIVE
   BVS: 0x70, // Branch if overflow set | RELATIVE
   BVC: 0x50, // Branch if overflow clear | RELATIVE
+  // Zero page addressing
+  LDAZ: 0xa5, // Load A from zero page | ZERO PAGE
+  STAZ: 0x85, // Store A to zero page | ZERO PAGE
+  LDXZ: 0xa6, // Load X from zero page | ZERO PAGE
+  STXZ: 0x86, // Store X to zero page | ZERO PAGE
+  LDYZ: 0xa4, // Load Y from zero page | ZERO PAGE
+  STYZ: 0x84, // Store Y to zero page | ZERO PAGE
+  ADCZ: 0x65, // Add with carry zero page | ZERO PAGE
+  SBCZ: 0xe5, // Subtract with carry zero page | ZERO PAGE
+  ANDZ: 0x25, // AND zero page | ZERO PAGE
+  ORAZ: 0x05, // ORA zero page | ZERO PAGE
+  EORZ: 0x45, // EOR zero page | ZERO PAGE
+  CMPZ: 0xc5, // Compare A zero page | ZERO PAGE
+  CPXZ: 0xe4, // Compare X zero page | ZERO PAGE
+  CPYZ: 0xc4, // Compare Y zero page | ZERO PAGE
+  BITZ: 0x24, // Bit test zero page | ZERO PAGE
+  ASLZ: 0x06, // ASL zero page | ZERO PAGE
+  LSRZ: 0x46, // LSR zero page | ZERO PAGE
+  ROLZ: 0x26, // ROL zero page | ZERO PAGE
+  RORZ: 0x66, // ROR zero page | ZERO PAGE
+  INCZ: 0xe6, // INC zero page | ZERO PAGE
+  DECZ: 0xc6, // DEC zero page | ZERO PAGE
+  // Zero page indexed
+  LDAZX: 0xb5, // Load A from zero page,X | ZERO PAGE,X
+  STAZX: 0x95, // Store A to zero page,X | ZERO PAGE,X
+  LDYZX: 0xb4, // Load Y from zero page,X | ZERO PAGE,X
+  STYZX: 0x94, // Store Y to zero page,X | ZERO PAGE,X
+  ADCZX: 0x75, // ADC zero page,X | ZERO PAGE,X
+  SBCZX: 0xf5, // SBC zero page,X | ZERO PAGE,X
+  ANDZX: 0x35, // AND zero page,X | ZERO PAGE,X
+  ORAZX: 0x15, // ORA zero page,X | ZERO PAGE,X
+  EORZX: 0x55, // EOR zero page,X | ZERO PAGE,X
+  CMPZX: 0xd5, // CMP zero page,X | ZERO PAGE,X
+  ASLZX: 0x16, // ASL zero page,X | ZERO PAGE,X
+  LSRZX: 0x56, // LSR zero page,X | ZERO PAGE,X
+  ROLZX: 0x36, // ROL zero page,X | ZERO PAGE,X
+  RORZX: 0x76, // ROR zero page,X | ZERO PAGE,X
+  INCZX: 0xf6, // INC zero page,X | ZERO PAGE,X
+  DECZX: 0xd6, // DEC zero page,X | ZERO PAGE,X
+  LDXZY: 0xb6, // Load X from zero page,Y | ZERO PAGE,Y
+  STXZY: 0x96, // Store X to zero page,Y | ZERO PAGE,Y
+  // Absolute indexed
+  LDAAX: 0xbd, // Load A from absolute,X | ABSOLUTE,X
+  STAAX: 0x9d, // Store A to absolute,X | ABSOLUTE,X
+  LDYAX: 0xbc, // Load Y from absolute,X | ABSOLUTE,X
+  ADCAX: 0x7d, // ADC absolute,X | ABSOLUTE,X
+  SBCAX: 0xfd, // SBC absolute,X | ABSOLUTE,X
+  ANDAX: 0x3d, // AND absolute,X | ABSOLUTE,X
+  ORAAX: 0x1d, // ORA absolute,X | ABSOLUTE,X
+  EORAX: 0x5d, // EOR absolute,X | ABSOLUTE,X
+  CMPAX: 0xdd, // CMP absolute,X | ABSOLUTE,X
+  ASLAX: 0x1e, // ASL absolute,X | ABSOLUTE,X
+  LSRAX: 0x5e, // LSR absolute,X | ABSOLUTE,X
+  ROLAX: 0x3e, // ROL absolute,X | ABSOLUTE,X
+  RORAX: 0x7e, // ROR absolute,X | ABSOLUTE,X
+  INCAX: 0xfe, // INC absolute,X | ABSOLUTE,X
+  DECAX: 0xde, // DEC absolute,X | ABSOLUTE,X
+  LDAAY: 0xb9, // Load A from absolute,Y | ABSOLUTE,Y
+  STAAY: 0x99, // Store A to absolute,Y | ABSOLUTE,Y
+  LDXAY: 0xbe, // Load X from absolute,Y | ABSOLUTE,Y
+  ADCAY: 0x79, // ADC absolute,Y | ABSOLUTE,Y
+  SBCAY: 0xf9, // SBC absolute,Y | ABSOLUTE,Y
+  ANDAY: 0x39, // AND absolute,Y | ABSOLUTE,Y
+  ORAAY: 0x19, // ORA absolute,Y | ABSOLUTE,Y
+  EORAY: 0x59, // EOR absolute,Y | ABSOLUTE,Y
+  CMPAY: 0xd9, // CMP absolute,Y | ABSOLUTE,Y
   JSR: 0x20, // Jump to subroutine | ABSOLUTE
   RTS: 0x60, // Return from subroutine | IMPLIED
   PHA: 0x48, // Push accumulator | IMPLIED
@@ -132,6 +198,8 @@ type ControlWord = {
   spdi: boolean; // input stack pointer from data bus
   sto: boolean; // output status register as byte to data bus
   sti: boolean; // input status register from data bus byte
+  dEa: boolean; // address add: aluA + aluB with carry=0, no flag updates
+  dahc: boolean; // add address carry to high byte of bus address register
   if: { flag: string; value: boolean }[]; // Cpu status flags to set immediately
 };
 
@@ -187,6 +255,8 @@ const baseControl: ControlWord = {
   spdi: false, // input stack pointer from data bus
   sto: false, // output status register as byte to data bus
   sti: false, // input status register from data bus byte
+  dEa: false, // address add: aluA + aluB with carry=0, no flag updates
+  dahc: false, // add address carry to high byte of bus address register
   if: [], // Cpu status flags to set immediately
 };
 
@@ -582,6 +652,622 @@ const instructions: { [key: number]: { [key: string]: MicroInstructions } } = {
   [instructionMap.BVC]: {
     O: [Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, pce: true })],
     0: [Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true, bra: true })],
+  },
+  // Zero page addressing — same as absolute but only 1 address byte (high byte implicitly $00)
+  [instructionMap.LDAZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LDXZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, xi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STXZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, xo: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LDYZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, yi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STYZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, yo: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ADCZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  [instructionMap.CPXZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { xo: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  [instructionMap.CPYZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { yo: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  [instructionMap.BITZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, bit: true, fi: true }),
+    ],
+  },
+  [instructionMap.ASLZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { asl: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LSRZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { lsr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ROLZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { rol: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.RORZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { ror: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.INCZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dE: true, fi: true, if: [{ flag: 'C', value: false }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.DECZ]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dal: true, pce: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dS: true, fi: true, if: [{ flag: 'C', value: true }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  // Zero page,X indexed — base + X through ALU with carry=0
+  [instructionMap.LDAZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LDYZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, yi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STYZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, yo: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ADCZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  [instructionMap.ASLZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { asl: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LSRZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { lsr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ROLZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { rol: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.RORZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { ror: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.INCZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dE: true, fi: true, if: [{ flag: 'C', value: false }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.DECZX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dS: true, fi: true, if: [{ flag: 'C', value: true }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  // Zero page,Y indexed
+  [instructionMap.LDXZY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, xi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STXZY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, xo: true, ri: true, bac: true }),
+    ],
+  },
+  // Absolute,X indexed
+  [instructionMap.LDAAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LDYAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, yi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.ADCAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
+  },
+  [instructionMap.ASLAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { asl: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LSRAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { lsr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.ROLAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { rol: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.RORAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { ror: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.INCAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dE: true, fi: true, if: [{ flag: 'C', value: false }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.DECAX]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { xo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, la: true }),
+      Object.assign({ ...baseControl }, { c1: true, dS: true, fi: true, if: [{ flag: 'C', value: true }] }),
+      Object.assign({ ...baseControl }, { so: true, ri: true, bac: true }),
+    ],
+  },
+  // Absolute,Y indexed
+  [instructionMap.LDAAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, ai: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.STAAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ao: true, ri: true, bac: true }),
+    ],
+  },
+  [instructionMap.LDXAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, xi: true, bac: true, zn: true }),
+    ],
+  },
+  [instructionMap.ADCAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dE: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.SBCAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dS: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ANDAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dAnd: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.ORAAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dOr: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.EORAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dXor: true, fi: true }),
+      Object.assign({ ...baseControl }, { so: true, ai: true }),
+    ],
+  },
+  [instructionMap.CMPAY]: {
+    0: [
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, la: true, pce: true }),
+      Object.assign({ ...baseControl }, { pco: true, mi: true, ro: true, dah: true, pce: true }),
+      Object.assign({ ...baseControl }, { yo: true, lb: true }),
+      Object.assign({ ...baseControl }, { dEa: true }),
+      Object.assign({ ...baseControl }, { so: true, dal: true, dahc: true }),
+      Object.assign({ ...baseControl }, { bao: true, mi: true, ro: true, lb: true, bac: true }),
+      Object.assign({ ...baseControl }, { ao: true, la: true, dc: true, fi: true }),
+    ],
   },
   // Stack operations
   [instructionMap.JSR]: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,7 +52,7 @@ const cycle = (machineState: MachineState): MachineState => {
   }
 
   // Real busses are cleared just by having no signals output on them
-  mainBus = clearBus(mainBus, controlWord);
+  mainBus = clearBus(mainBus);
 
   cpuRegisters = setImmediateFlags({ controlWord, cpuRegisters });
 

--- a/lib/initial-state/index.ts
+++ b/lib/initial-state/index.ts
@@ -22,6 +22,7 @@ type CpuRegisters = {
   pc: number; // 16 bit program counter
   sp: number; // 8 bit stack pointer
   o: number; // 8 bit output register
+  addressCarry: boolean; // internal carry latch for address arithmetic
   status: {
     [C: string]: boolean; // Carry
     Z: boolean; // Zero
@@ -59,6 +60,7 @@ const setupCpuRegisters = (): CpuRegisters => {
     pc: 0b0000000000000000,
     sp: 0xff,
     o: 0b00000000,
+    addressCarry: false,
     status: {
       C: false,
       Z: false,

--- a/lib/register/index.ts
+++ b/lib/register/index.ts
@@ -272,9 +272,9 @@ const incrementInstructionCounter = (register: number, controlWord: ControlWord)
     return 0b000; // reset the instruction counter if the program counter was set on this cycle
   }
 
-  // 3 bit counter, so roll back to zero if it equals 7
-  if (register >= 0b111) {
-    return 0b000;
+  // 4 bit counter, so roll back to zero if it equals 15
+  if (register >= 0b1111) {
+    return 0b0000;
   }
 
   return register + 1;

--- a/lib/register/index.ts
+++ b/lib/register/index.ts
@@ -191,7 +191,7 @@ const interfaceAllDataRegisters = ({
   ({ bus: mainBus, register: cpuRegisters.aluA } = interfaceRegisterData({
     bus: mainBus,
     register: cpuRegisters.aluA,
-    output: output && false,
+    output: output && controlWord.lao,
     input: input && controlWord.la,
   }));
 

--- a/test.s
+++ b/test.s
@@ -1,7 +1,7 @@
 ; simpleCPU test suite
 ; Exercises every implemented instruction
 ; Output to $FE00 — each STA $FE00 prints a test result
-; Expected output: 1 through 34, then 3 2 1 35, 36 37 38 39 40, then Hello World!
+; Expected output: 1 through 34, then 3 2 1 35, 36-58, then Hello World!
 
 * = $0200
 
@@ -15,9 +15,9 @@
         STA $FE00       ; output 2
 
 ; --- Test 3: STA / LDA absolute ---
-        STA $0500       ; store 2 at $0500
+        STA $0600       ; store 2 at $0600
         LDA #$00        ; clear A
-        LDA $0500       ; reload from $0500, A=2
+        LDA $0600       ; reload from $0600, A=2
         CLC
         ADC #$01        ; A=3
         STA $FE00       ; output 3
@@ -52,22 +52,22 @@
 
 ; --- Test 10: LDX absolute ---
         LDA #$0A
-        STA $0500
-        LDX $0500       ; X=10
+        STA $0600
+        LDX $0600       ; X=10
         STX $FE00       ; output 10
 
 ; --- Test 11: LDY absolute ---
         LDA #$0B
-        STA $0500
-        LDY $0500       ; Y=11
+        STA $0600
+        LDY $0600       ; Y=11
         STY $FE00       ; output 11
 
 ; --- Test 12: ADC absolute ---
         LDA #$06
-        STA $0500       ; store 6
+        STA $0600       ; store 6
         LDA #$06
         CLC
-        ADC $0500       ; A=6+6=12
+        ADC $0600       ; A=6+6=12
         STA $FE00       ; output 12
 
 ; --- Test 13: SBC immediate ---
@@ -78,10 +78,10 @@
 
 ; --- Test 14: SBC absolute ---
         LDA #$04
-        STA $0500       ; store 4
+        STA $0600       ; store 4
         LDA #$12        ; A=18
         SEC
-        SBC $0500       ; A=18-4=14
+        SBC $0600       ; A=18-4=14
         STA $FE00       ; output 14
 
 ; --- Test 15: AND immediate ---
@@ -91,9 +91,9 @@
 
 ; --- Test 16: AND absolute ---
         LDA #$F0
-        STA $0500
+        STA $0600
         LDA #$1F
-        AND $0500       ; A=$1F & $F0 = $10 = 16
+        AND $0600       ; A=$1F & $F0 = $10 = 16
         STA $FE00       ; output 16
 
 ; --- Test 17: ORA immediate ---
@@ -103,9 +103,9 @@
 
 ; --- Test 18: ORA absolute ---
         LDA #$02
-        STA $0500
+        STA $0600
         LDA #$10
-        ORA $0500       ; A=$10 | $02 = $12 = 18
+        ORA $0600       ; A=$10 | $02 = $12 = 18
         STA $FE00       ; output 18
 
 ; --- Test 19: EOR immediate ---
@@ -125,9 +125,9 @@
 ; need A XOR mem = 20 = $14 = 00010100
 ; $FF ^ $EB = $14? $EB=11101011 XOR $FF=11111111 = 00010100 = $14 = 20 yes
         LDA #$EB
-        STA $0500
+        STA $0600
         LDA #$FF
-        EOR $0500       ; A=$FF ^ $EB = $14 = 20
+        EOR $0600       ; A=$FF ^ $EB = $14 = 20
         STA $FE00       ; output 20
 
 ; --- Test 21: ASL accumulator ---
@@ -168,10 +168,10 @@
         STX $FE00       ; output 25
 ; verify Y survived
         LDA #$AA
-        STA $0500
-        STY $0501
-        LDA $0501
-        CMP $0500       ; Y should still be $AA
+        STA $0600
+        STY $0601
+        LDA $0601
+        CMP $0600       ; Y should still be $AA
 ; (if Z is not set, something went wrong — but we can't branch yet)
 
 ; --- Test 26: INY / DEY ---
@@ -181,10 +181,10 @@
         STY $FE00       ; output 26
 ; verify X survived
         LDA #$BB
-        STA $0500
-        STX $0501
-        LDA $0501
-        CMP $0500       ; X should still be $BB
+        STA $0600
+        STX $0601
+        LDA $0601
+        CMP $0600       ; X should still be $BB
 
 ; --- Test 27: BEQ (branch if Z=1) ---
         LDA #$00        ; Z=1
@@ -286,19 +286,162 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
 ; --- Test 40: Nested JSR ---
         JSR SUB40       ; calls SUB40B which outputs 40
 
+; --- Test 41: LDA/STA zero page ---
+        LDA #$29        ; 41
+        STA $40         ; store 41 to zero page $40
+        LDA #$00        ; clear A
+        LDA $40         ; reload from zero page
+        STA $FE00       ; output 41
+
+; --- Test 42: LDX/STX zero page ---
+        LDX #$2A        ; 42
+        STX $41         ; store to zero page $41
+        LDX #$00        ; clear X
+        LDX $41         ; reload from zero page
+        STX $FE00       ; output 42
+
+; --- Test 43: LDY/STY zero page ---
+        LDY #$2B        ; 43
+        STY $42         ; store to zero page $42
+        LDY #$00        ; clear Y
+        LDY $42         ; reload from zero page
+        STY $FE00       ; output 43
+
+; --- Test 44: ADC zero page ---
+        LDA #$14        ; 20
+        STA $40         ; store 20 to ZP
+        LDA #$18        ; 24
+        CLC
+        ADC $40         ; 24+20=44
+        STA $FE00       ; output 44
+
+; --- Test 45: SBC zero page ---
+        LDA #$05
+        STA $40
+        LDA #$32        ; 50
+        SEC
+        SBC $40         ; 50-5=45
+        STA $FE00       ; output 45
+
+; --- Test 46: AND/ORA/EOR zero page ---
+        LDA #$FE
+        STA $40
+        LDA #$2F        ; $2F = 47
+        AND $40         ; $2F & $FE = $2E = 46
+        STA $FE00       ; output 46
+
+; --- Test 47: CMP zero page ---
+        LDA #$2F        ; 47
+        STA $40
+        LDA #$2F
+        CMP $40         ; Z=1 (equal)
+        BEQ T47OK
+        BRK
+T47OK   LDA #$2F        ; 47
+        STA $FE00       ; output 47
+
+; --- Test 48: INC/DEC zero page ---
+        LDA #$2F        ; 47
+        STA $40
+        INC $40         ; ZP[$40] = 48
+        LDA $40
+        STA $FE00       ; output 48
+
+; --- Test 49: LDA/STA zero page,X ---
+        LDA #$31        ; 49
+        LDX #$05
+        STA $40,X       ; store 49 to ZP[$45]
+        LDA #$00        ; clear A
+        LDA $40,X       ; load from ZP[$45]
+        STA $FE00       ; output 49
+
+; --- Test 50: LDX/STX zero page,Y ---
+        LDX #$32        ; 50
+        LDY #$03
+        STX $50,Y       ; store 50 to ZP[$53]
+        LDX #$00        ; clear X
+        LDX $50,Y       ; load from ZP[$53]
+        STX $FE00       ; output 50
+
+; --- Test 51: ADC zero page,X ---
+        LDA #$19        ; 25
+        LDX #$02
+        STA $60,X       ; store 25 to ZP[$62]
+        LDA #$1A        ; 26
+        CLC
+        ADC $60,X       ; 26+25=51
+        STA $FE00       ; output 51
+
+; --- Test 52: INC zero page,X ---
+        LDA #$33        ; 51
+        LDX #$04
+        STA $70,X       ; store 51 to ZP[$74]
+        INC $70,X       ; ZP[$74]=52
+        LDA $70,X
+        STA $FE00       ; output 52
+
+; --- Test 53: ZP,X wraps within zero page ---
+        LDA #$35        ; 53
+        LDX #$10
+        STA $F5,X       ; $F5+$10=$105, wraps to $05
+        LDA #$00
+        LDA $F5,X       ; load from ZP[$05]
+        STA $FE00       ; output 53
+
+; --- Test 54: LDA/STA absolute,X ---
+        LDA #$36        ; 54
+        LDX #$03
+        STA $0600,X     ; store 54 to $0503
+        LDA #$00
+        LDA $0600,X     ; load from $0503
+        STA $FE00       ; output 54
+
+; --- Test 55: LDA absolute,Y ---
+        LDA #$37        ; 55
+        LDY #$05
+        STA $0600,Y     ; store 55 to $0505
+        LDA #$00
+        LDA $0600,Y     ; load from $0505
+        STA $FE00       ; output 55
+
+; --- Test 56: ADC absolute,X ---
+        LDA #$1C        ; 28
+        LDX #$02
+        STA $0600,X     ; store 28 to $0502
+        LDA #$1C        ; 28
+        CLC
+        ADC $0600,X     ; 28+28=56
+        STA $FE00       ; output 56
+
+; --- Test 57: Page crossing absolute,X ---
+        LDA #$39        ; 57
+        LDX #$01
+        STA $05FF,X     ; $05FF+1=$0600, crosses page
+        LDA #$00
+        LDA $05FF,X     ; load from $0600 (page crossing)
+        STA $FE00       ; output 57
+
+; --- Test 58: Page crossing absolute,Y ---
+        LDA #$3A        ; 58
+        LDY #$02
+        STA $05FF,Y     ; $05FF+2=$0601, crosses page
+        LDA #$00
+        LDA $05FF,Y     ; load from $0601
+        STA $FE00       ; output 58
+
 ; --- Smoke tests for remaining instructions (no output, just must not crash) ---
 
 ; STX / STY absolute
         LDX #$42
-        STX $0500
+        STX $0600
         LDY #$43
-        STY $0501
+        STY $0601
 
 ; INC / DEC memory
         LDA #$09
-        STA $0500
-        INC $0500       ; mem[$0500]=10
-        DEC $0500       ; mem[$0500]=9
+        STA $0600
+        INC $0600       ; mem[$0600]=10
+        DEC $0600       ; mem[$0600]=9
 
 ; CMP immediate / absolute
         LDA #$05
@@ -306,9 +449,9 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CMP #$06        ; Z=0, C=0
 
         LDA #$05
-        STA $0500
+        STA $0600
         LDA #$05
-        CMP $0500       ; Z=1, C=1
+        CMP $0600       ; Z=1, C=1
 
 ; CPX immediate / absolute
         LDX #$10
@@ -316,8 +459,8 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CPX #$11        ; Z=0, C=0
 
         LDA #$10
-        STA $0500
-        CPX $0500       ; Z=1, C=1
+        STA $0600
+        CPX $0600       ; Z=1, C=1
 
 ; CPY immediate / absolute
         LDY #$20
@@ -325,24 +468,24 @@ COUNT   STX $FE00       ; output 35, 36, 37 (values 3, 2, 1)
         CPY #$21        ; Z=0, C=0
 
         LDA #$20
-        STA $0500
-        CPY $0500       ; Z=1, C=1
+        STA $0600
+        CPY $0600       ; Z=1, C=1
 
 ; ASL / LSR / ROL / ROR absolute
         LDA #$02
-        STA $0500
-        ASL $0500       ; mem[$0500]=4
-        LSR $0500       ; mem[$0500]=2
+        STA $0600
+        ASL $0600       ; mem[$0600]=4
+        LSR $0600       ; mem[$0600]=2
         CLC
-        ROL $0500       ; mem[$0500]=4
+        ROL $0600       ; mem[$0600]=4
         CLC
-        ROR $0500       ; mem[$0500]=2
+        ROR $0600       ; mem[$0600]=2
 
 ; BIT absolute
         LDA #$FF
-        STA $0500
+        STA $0600
         LDA #$0F
-        BIT $0500       ; Z=0 (0F & FF != 0), N=1, V=1
+        BIT $0600       ; Z=0 (0F & FF != 0), N=1, V=1
 
 ; SEC / CLC
         SEC

--- a/test.s
+++ b/test.s
@@ -1,7 +1,7 @@
 ; simpleCPU test suite
 ; Exercises every implemented instruction
 ; Output to $FE00 — each STA $FE00 prints a test result
-; Expected output: 1 through 34, then 3 2 1 35, 36-58, then Hello World!
+; Expected output: 1 through 34, then 3 2 1 35, 36-63, then Hello World!
 
 * = $0200
 
@@ -428,6 +428,63 @@ T47OK   LDA #$2F        ; 47
         LDA #$00
         LDA $05FF,Y     ; load from $0601
         STA $FE00       ; output 58
+
+; --- Test 59: JMP indirect ---
+        LDA #<T59TGT    ; low byte of target address
+        STA $60         ; store at ZP $60
+        LDA #>T59TGT    ; high byte of target address
+        STA $61         ; store at ZP $61
+        JMP ($0060)     ; jump through pointer at $0060
+        BRK             ; trap — should be skipped
+T59TGT  LDA #$3B        ; 59
+        STA $FE00       ; output 59
+
+; --- Test 60: LDA (zp,X) indexed indirect ---
+        LDA #<T60DAT    ; low byte of data address
+        LDX #$04
+        STA $70,X       ; store pointer low at ZP[$74]
+        LDA #>T60DAT    ; high byte of data address
+        STA $75         ; store pointer high at ZP[$75]
+        LDA #$00        ; clear A
+        LDA ($70,X)     ; read through pointer at ZP[$74]
+        STA $FE00       ; output 60
+        JMP T60END
+T60DAT  .BYTE $3C       ; 60
+T60END
+
+; --- Test 61: STA (zp,X) indexed indirect ---
+        LDA #<$0600     ; low byte of $0600
+        STA $76         ; pointer low at ZP[$76]
+        LDA #>$0600     ; high byte of $0600
+        STA $77         ; pointer high at ZP[$77]
+        LDA #$3D        ; 61
+        LDX #$06
+        STA ($70,X)     ; store through pointer at ZP[$76] → $0600
+        LDA $0600       ; verify
+        STA $FE00       ; output 61
+
+; --- Test 62: LDA (zp),Y indirect indexed ---
+        LDA #<T62DAT    ; low byte of data base
+        STA $80         ; pointer low at ZP[$80]
+        LDA #>T62DAT    ; high byte of data base
+        STA $81         ; pointer high at ZP[$81]
+        LDY #$03        ; offset
+        LDA ($80),Y     ; read from T62DAT+3
+        STA $FE00       ; output 62
+        JMP T62END
+T62DAT  .BYTE $00,$00,$00,$3E  ; data[3] = 62
+T62END
+
+; --- Test 63: STA (zp),Y indirect indexed ---
+        LDA #<$0600     ; pointer to $0600
+        STA $82
+        LDA #>$0600
+        STA $83
+        LDA #$3F        ; 63
+        LDY #$05
+        STA ($82),Y     ; store at $0600+5=$0605
+        LDA $0605       ; verify
+        STA $FE00       ; output 63
 
 ; --- Smoke tests for remaining instructions (no output, just must not crash) ---
 


### PR DESCRIPTION
## Addressing Modes

Implements all major 6502 addressing modes, adding 101 new opcodes across 6 categories:

### Step 1: Zero Page (21 opcodes)
Same as absolute but with 1-byte address (high byte implicitly $00). Faster, fewer cycles.

### Step 2: Zero Page,X / Zero Page,Y (18 opcodes)
Address math routed through existing ALU. New `dEa` signal — add with carry forced to 0, no flag side effects. Wraps within page zero.

### Step 3: Absolute,X / Absolute,Y (25 opcodes)
16-bit base + index register. Internal `addressCarry` latch detects page crossings, `dahc` signal applies carry to high byte. Instruction counter widened from 3 to 4 bits to support longer microcode sequences.

### Step 4: JMP Indirect (1 opcode)
Pointer dereference — reads 16-bit target address from memory. Required two infrastructure changes:
- `bac` now processes before `dal`/`dah` (clear-then-set, enables building new address in same cycle as clearing old)
- `lao` signal outputs aluA latch to data bus (temporary storage for pointer bytes)

### Step 5: Indexed Indirect — `(zp,X)` (8 opcodes)
Combines ZP+X address math with pointer dereference. 8 micro-ops for load, 8 for store.

### Step 6: Indirect Indexed — `(zp),Y` (8 opcodes)
Pointer dereference from zero page, then add Y with page crossing support. The workhorse mode for pointer+offset access.

### New Control Signals
- `dEa` — ALU add with carry=0, no flag updates (address math)
- `dahc` — apply address carry to high byte
- `bai` — increment bus address register by 1
- `lao` — output aluA latch to data bus

### Tests
63 tests passing (was 40), including page crossing, ZP wrap, inline data, and pointer round-trip verification.